### PR TITLE
Dockerを使用した環境構築の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:3.0.2-alpine3.12
+
+ARG RAILS_ENV
+ARG RAILS_MASTER_KEY
+
+WORKDIR /myapp
+
+COPY . .
+
+RUN apk update \
+    && apk add --no-cache --virtual=.build-deps \
+    build-base \
+    && apk add --no-cache \
+    mariadb-dev \
+    tzdata \
+    nodejs~=12 \
+    yarn \
+    && gem install bundler:2.2.24 \
+    && bundle install \
+    && yarn install \
+    && rails assets:precompile \
+    && apk del .build-deps
+
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
+EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+## Dockerを使った開発環境の構築
+以下を順番に実行する。
+```
+$ docker compose build
+```
+```
+$ docker compose run --rm bundle exec rails db:create
+```
+```
+$ docker compose run --rm bundle exec rails db:migrate
+```
+```
+$ docker compose up
+```
+`localhost:3000`にアクセスしてトップが表示される。
 
 # groovy-grouping
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
 development:
   <<: *default
   database: groovy_grouping_development
+  host: <%= ENV['DATABASE_HOST'] %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -27,6 +28,7 @@ development:
 test:
   <<: *default
   database: groovy_grouping_test
+  host: <%= ENV['DATABASE_HOST'] %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+
+services:
+  app: &app_base
+    build: .
+    command: ash -c "rm -f tmp/pids/server.pid && rails s -p 3000 -b '0.0.0.0'"
+    depends_on:
+      - db
+    environment:
+      - DATABASE_HOST=db
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/myapp:delegated
+
+  db:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  db:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /myapp/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"


### PR DESCRIPTION
## 背景
ローカルにMySQLを入れなくても環境構築を可能にしたい

## やったこと

- [x] Docker周りのファイルを追加
- [x] Dockerで使用するhostの設定を`database.yml`に追加
- [x] Readmeの更新

## やってないこと
- pryをDocker環境で使えるようにする